### PR TITLE
Fix OCaml runtime build and add tests

### DIFF
--- a/ocaml/dune-project
+++ b/ocaml/dune-project
@@ -1,0 +1,3 @@
+(lang dune 3.14)
+(name vere)
+(generate_opam_files false)

--- a/ocaml/runtime/allocate.ml
+++ b/ocaml/runtime/allocate.ml
@@ -1,0 +1,359 @@
+open Bigarray
+
+type profile_snapshot = {
+  allocations : int;
+  frees : int;
+  reallocations : int;
+  words_allocated : int;
+  words_freed : int;
+  peak_words : int;
+}
+
+module Hooks = struct
+  type t = {
+    mutable allocation : (int -> unit) list;
+    mutable free : (int -> unit) list;
+    mutable reallocation : (int -> int -> unit) list;
+  }
+
+  let create () = { allocation = []; free = []; reallocation = [] }
+
+  let notify_allocation t words =
+    List.iter (fun hook -> hook words) t.allocation
+
+  let notify_free t words =
+    List.iter (fun hook -> hook words) t.free
+
+  let notify_reallocation t old_words new_words =
+    List.iter (fun hook -> hook old_words new_words) t.reallocation
+end
+
+module Profile = struct
+  type t = {
+    mutable allocations : int;
+    mutable frees : int;
+    mutable reallocations : int;
+    mutable words_allocated : int;
+    mutable words_freed : int;
+    mutable peak_words : int;
+    mutable current_words : int;
+  }
+
+  let create () =
+    {
+      allocations = 0;
+      frees = 0;
+      reallocations = 0;
+      words_allocated = 0;
+      words_freed = 0;
+      peak_words = 0;
+      current_words = 0;
+    }
+
+  let record_alloc t words =
+    t.allocations <- t.allocations + 1;
+    t.words_allocated <- t.words_allocated + words;
+    t.current_words <- t.current_words + words;
+    if t.current_words > t.peak_words then
+      t.peak_words <- t.current_words
+
+  let record_free t words =
+    t.frees <- t.frees + 1;
+    t.words_freed <- t.words_freed + words;
+    t.current_words <- max 0 (t.current_words - words)
+
+  let record_realloc t old_words new_words =
+    t.reallocations <- t.reallocations + 1;
+    (* count as a free + alloc for aggregate stats *)
+    record_free t old_words;
+    record_alloc t new_words
+
+  let snapshot t =
+    {
+      allocations = t.allocations;
+      frees = t.frees;
+      reallocations = t.reallocations;
+      words_allocated = t.words_allocated;
+      words_freed = t.words_freed;
+      peak_words = t.peak_words;
+    }
+
+  let reset t =
+    t.allocations <- 0;
+    t.frees <- 0;
+    t.reallocations <- 0;
+    t.words_allocated <- 0;
+    t.words_freed <- 0;
+    t.peak_words <- t.current_words
+end
+
+type mark_state = {
+  mutable bitset : (int32, int32_elt, c_layout) Array1.t;
+  mutable buffer : (int32, int32_elt, c_layout) Array1.t;
+  mutable size : int;
+  mutable len : int;
+  wee : int array;
+}
+
+type pack_state = {
+  mutable bitset : (int32, int32_elt, c_layout) Array1.t;
+  mutable pap : (int32, int32_elt, c_layout) Array1.t;
+  mutable pum : (int32, int32_elt, c_layout) Array1.t;
+  mutable buffer : (int32, int32_elt, c_layout) Array1.t;
+  mutable size : int;
+  mutable len : int;
+}
+
+type road = {
+  mutable heap_words : int;
+  mark : mark_state;
+  pack : pack_state;
+  profile : Profile.t;
+  hooks : Hooks.t;
+}
+
+let default_heap_words = 1 lsl 20
+let default_mark_size = 1 lsl 12
+let default_pack_size = 1 lsl 12
+let crag_slots = 1 lsl 6
+
+let empty_words () = Array1.create Int32 C_layout 0
+
+let make_mark_state () =
+  {
+    bitset = empty_words ();
+    buffer = empty_words ();
+    size = 0;
+    len = 0;
+    wee = Array.make crag_slots 0;
+  }
+
+let make_pack_state () =
+  {
+    bitset = empty_words ();
+    pap = empty_words ();
+    pum = empty_words ();
+    buffer = empty_words ();
+    size = 0;
+    len = 0;
+  }
+
+let the_road : road option ref = ref None
+
+let ensure_mark_capacity (state : mark_state) len =
+  if len > state.size - state.len then begin
+    let need = state.len + len in
+    let next = max (state.size * 2) (max default_mark_size need) in
+    let resized = Array1.create Int32 C_layout next in
+    if state.len > 0 then
+      Array1.blit (Array1.sub state.buffer 0 state.len) (Array1.sub resized 0 state.len);
+    state.buffer <- resized;
+    state.size <- next
+  end
+
+let ensure_pack_capacity state len =
+  if len > state.size - state.len then begin
+    let need = state.len + len in
+    let next = max (state.size * 2) (max default_pack_size need) in
+    let resized = Array1.create Int32 C_layout next in
+    if state.len > 0 then
+      Array1.blit (Array1.sub state.buffer 0 state.len) (Array1.sub resized 0 state.len);
+    state.buffer <- resized;
+    state.size <- next
+  end
+
+let make_road () =
+  {
+    heap_words = default_heap_words;
+    mark = make_mark_state ();
+    pack = make_pack_state ();
+    profile = Profile.create ();
+    hooks = Hooks.create ();
+  }
+
+let road () =
+  match !the_road with
+  | Some road -> road
+  | None ->
+      let road = make_road () in
+      the_road := Some road;
+      road
+
+let init_once () = ignore (road ())
+
+let init_heap ?(words = default_heap_words) () =
+  let road = road () in
+  road.heap_words <- words;
+  Profile.reset road.profile;
+  Array.fill road.mark.wee 0 (Array.length road.mark.wee) 0;
+  road.mark.bitset <- Array1.create Int32 C_layout ((words + 31) / 32);
+  road.mark.buffer <- Array1.create Int32 C_layout (max default_mark_size words);
+  road.mark.size <- Array1.dim road.mark.buffer;
+  road.mark.len <- 0;
+  road.pack.bitset <- Array1.create Int32 C_layout ((words + 31) / 32);
+  road.pack.pap <- Array1.create Int32 C_layout ((words + 31) / 32);
+  road.pack.pum <- Array1.create Int32 C_layout ((words + 31) / 32);
+  road.pack.buffer <- Array1.create Int32 C_layout (max default_pack_size words);
+  road.pack.size <- Array1.dim road.pack.buffer;
+  road.pack.len <- 0
+
+let drop_heap ~cap:_ ~ear:_ =
+  let road = road () in
+  road.mark.len <- 0;
+  road.pack.len <- 0
+
+let mark_init () =
+  let road = road () in
+  let words = road.heap_words in
+  road.mark.bitset <- Array1.create Int32 C_layout ((words + 31) / 32);
+  road.mark.buffer <- Array1.create Int32 C_layout (max default_mark_size words);
+  road.mark.size <- Array1.dim road.mark.buffer;
+  road.mark.len <- 0;
+  Array1.fill road.mark.bitset Int32.zero;
+  Array.fill road.mark.wee 0 (Array.length road.mark.wee) 0
+
+let mark_done () =
+  let road = road () in
+  road.mark.bitset <- empty_words ();
+  road.mark.buffer <- empty_words ();
+  road.mark.size <- 0;
+  road.mark.len <- 0
+
+let mark_alloc len =
+  let road = road () in
+  ensure_mark_capacity road.mark len;
+  let start = road.mark.len in
+  road.mark.len <- start + len;
+  Array1.sub road.mark.buffer start len
+
+let pack_init () =
+  let road = road () in
+  let words = road.heap_words in
+  road.pack.bitset <- Array1.create Int32 C_layout ((words + 31) / 32);
+  road.pack.pap <- Array1.create Int32 C_layout ((words + 31) / 32);
+  road.pack.pum <- Array1.create Int32 C_layout ((words + 31) / 32);
+  road.pack.buffer <- Array1.create Int32 C_layout (max default_pack_size words);
+  road.pack.size <- Array1.dim road.pack.buffer;
+  road.pack.len <- 0;
+  Array1.fill road.pack.bitset Int32.zero;
+  Array1.fill road.pack.pap Int32.zero;
+  Array1.fill road.pack.pum Int32.zero
+
+let pack_done () =
+  let road = road () in
+  road.pack.bitset <- empty_words ();
+  road.pack.pap <- empty_words ();
+  road.pack.pum <- empty_words ();
+  road.pack.buffer <- empty_words ();
+  road.pack.size <- 0;
+  road.pack.len <- 0
+
+let pack_alloc len =
+  let road = road () in
+  ensure_pack_capacity road.pack len;
+  let start = road.pack.len in
+  road.pack.len <- start + len;
+  Array1.sub road.pack.buffer start len
+
+let waloc len =
+  let road = road () in
+  let block = Array1.create Int32 C_layout len in
+  Profile.record_alloc road.profile len;
+  Hooks.notify_allocation road.hooks len;
+  block
+
+let wealloc old len =
+  let road = road () in
+  let block = Array1.create Int32 C_layout len in
+  let old_len = Array1.dim old in
+  let copy_len = min old_len len in
+  if copy_len > 0 then
+    Array1.blit (Array1.sub old 0 copy_len) (Array1.sub block 0 copy_len);
+  Profile.record_realloc road.profile old_len len;
+  Hooks.notify_reallocation road.hooks old_len len;
+  block
+
+let wfree block =
+  let road = road () in
+  let len = Array1.dim block in
+  Profile.record_free road.profile len;
+  Hooks.notify_free road.hooks len
+
+let wtrim block ~old ~len =
+  let road = road () in
+  Profile.record_realloc road.profile old len;
+  Hooks.notify_reallocation road.hooks old len;
+  ignore block
+
+let calloc num len =
+  let words = ((num * len) + 3) / 4 in
+  let block = waloc words in
+  for i = 0 to Array1.dim block - 1 do
+    Array1.set block i Int32.zero
+  done;
+  block
+
+let malloc bytes =
+  let words = (bytes + 3) / 4 in
+  waloc words
+
+let cell_words = 4
+
+let celloc () = waloc cell_words
+
+let cfree = wfree
+
+let realloc block_opt bytes =
+  match block_opt with
+  | None -> malloc bytes
+  | Some block ->
+      let words = (bytes + 3) / 4 in
+      wealloc block words
+
+let free = function
+  | None -> ()
+  | Some block -> wfree block
+
+let profile () =
+  let road = road () in
+  Profile.snapshot road.profile
+
+let reset_profile () =
+  let road = road () in
+  Profile.reset road.profile
+
+let register_allocation_hook hook =
+  let road = road () in
+  road.hooks.allocation <- hook :: road.hooks.allocation
+
+let register_free_hook hook =
+  let road = road () in
+  road.hooks.free <- hook :: road.hooks.free
+
+let register_reallocation_hook hook =
+  let road = road () in
+  road.hooks.reallocation <- hook :: road.hooks.reallocation
+
+let rec register_callbacks () =
+  Callback.register "u3a_ocaml_init_once" init_once;
+  Callback.register "u3a_ocaml_init_heap" (fun words -> init_heap ~words () );
+  Callback.register "u3a_ocaml_drop_heap" drop_heap;
+  Callback.register "u3a_ocaml_mark_init" mark_init;
+  Callback.register "u3a_ocaml_mark_done" mark_done;
+  Callback.register "u3a_ocaml_mark_alloc" mark_alloc;
+  Callback.register "u3a_ocaml_pack_init" pack_init;
+  Callback.register "u3a_ocaml_pack_done" pack_done;
+  Callback.register "u3a_ocaml_pack_alloc" pack_alloc;
+  Callback.register "u3a_ocaml_walloc" waloc;
+  Callback.register "u3a_ocaml_wealloc" wealloc;
+  Callback.register "u3a_ocaml_wfree" wfree;
+  Callback.register "u3a_ocaml_wtrim" wtrim;
+  Callback.register "u3a_ocaml_calloc" calloc;
+  Callback.register "u3a_ocaml_malloc" malloc;
+  Callback.register "u3a_ocaml_celloc" celloc;
+  Callback.register "u3a_ocaml_cfree" cfree;
+  Callback.register "u3a_ocaml_realloc" realloc;
+  Callback.register "u3a_ocaml_free" free;
+  Callback.register "u3a_ocaml_register_callbacks" register_callbacks
+
+let () = register_callbacks ()

--- a/ocaml/runtime/allocate.mli
+++ b/ocaml/runtime/allocate.mli
@@ -1,0 +1,64 @@
+open Bigarray
+
+(** OCaml re-implementation of the runtime allocation helpers traditionally
+    supplied by [pkg/noun/allocate.c]. The module mirrors the API shape needed
+    by the C runtime while exposing hooks that make it convenient to integrate
+    with OCaml-managed data. *)
+
+(** Opaque handle over the heap/road state. *)
+type road
+
+val init_once : unit -> unit
+(** Initialise global bookkeeping structures exactly once. *)
+
+val init_heap : ?words:int -> unit -> unit
+(** Prepare an OCaml-managed heap of [words] 32-bit cells. The default mirrors a
+    4 MiB arena. *)
+
+val drop_heap : cap:int -> ear:int -> unit
+(** Release transient accounting associated with the heap. The OCaml
+    implementation tracks statistics but does not presently recycle the
+    underlying buffers. *)
+
+val road : unit -> road
+(** Retrieve the current road, initialising it on demand. *)
+
+val mark_init : unit -> unit
+val mark_done : unit -> unit
+val mark_alloc : int -> (int32, int32_elt, c_layout) Array1.t
+
+val pack_init : unit -> unit
+val pack_done : unit -> unit
+val pack_alloc : int -> (int32, int32_elt, c_layout) Array1.t
+
+val waloc : int -> (int32, int32_elt, c_layout) Array1.t
+val wealloc : (int32, int32_elt, c_layout) Array1.t -> int -> (int32, int32_elt, c_layout) Array1.t
+val wfree : (int32, int32_elt, c_layout) Array1.t -> unit
+val wtrim : (int32, int32_elt, c_layout) Array1.t -> old:int -> len:int -> unit
+
+val calloc : int -> int -> (int32, int32_elt, c_layout) Array1.t
+val malloc : int -> (int32, int32_elt, c_layout) Array1.t
+val celloc : unit -> (int32, int32_elt, c_layout) Array1.t
+val cfree : (int32, int32_elt, c_layout) Array1.t -> unit
+val realloc : (int32, int32_elt, c_layout) Array1.t option -> int -> (int32, int32_elt, c_layout) Array1.t
+val free : (int32, int32_elt, c_layout) Array1.t option -> unit
+
+(** Profiling support. *)
+type profile_snapshot = {
+  allocations : int;
+  frees : int;
+  reallocations : int;
+  words_allocated : int;
+  words_freed : int;
+  peak_words : int;
+}
+
+val profile : unit -> profile_snapshot
+val reset_profile : unit -> unit
+
+val register_allocation_hook : (int -> unit) -> unit
+val register_free_hook : (int -> unit) -> unit
+val register_reallocation_hook : (int -> int -> unit) -> unit
+
+(** Register all OCaml functions with the C runtime. *)
+val register_callbacks : unit -> unit

--- a/ocaml/runtime/allocate_stubs.c
+++ b/ocaml/runtime/allocate_stubs.c
@@ -1,0 +1,304 @@
+#include <assert.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <caml/alloc.h>
+#include <caml/bigarray.h>
+#include <caml/callback.h>
+#include <caml/fail.h>
+#include <caml/memory.h>
+
+#include "pkg/noun/allocate_ocaml.h"
+
+typedef struct block_entry {
+  void* data;
+  mlsize_t length;
+  value bigarray;
+  struct block_entry* next;
+} block_entry;
+
+static block_entry* g_blocks = NULL;
+
+static block_entry*
+find_block(void* data)
+{
+  for ( block_entry* entry = g_blocks; entry; entry = entry->next ) {
+    if ( entry->data == data ) {
+      return entry;
+    }
+  }
+  return NULL;
+}
+
+static void
+remove_block(void* data)
+{
+  block_entry** cur = &g_blocks;
+  while ( *cur ) {
+    if ( (*cur)->data == data ) {
+      block_entry* doomed = *cur;
+      *cur = doomed->next;
+      caml_remove_generational_global_root(&doomed->bigarray);
+      free(doomed);
+      return;
+    }
+    cur = &(*cur)->next;
+  }
+}
+
+static block_entry*
+register_block(void* data, value bigarray, mlsize_t length)
+{
+  block_entry* entry = find_block(data);
+  if ( entry ) {
+    caml_remove_generational_global_root(&entry->bigarray);
+    entry->data = data;
+    entry->bigarray = bigarray;
+    entry->length = length;
+    caml_register_generational_global_root(&entry->bigarray);
+    return entry;
+  }
+
+  entry = malloc(sizeof(*entry));
+  if ( NULL == entry ) {
+    caml_failwith("u3a_ocaml: out of memory");
+  }
+  entry->data = data;
+  entry->length = length;
+  entry->bigarray = bigarray;
+  entry->next = g_blocks;
+  g_blocks = entry;
+  caml_register_generational_global_root(&entry->bigarray);
+  return entry;
+}
+
+static value*
+named_function(const char* name)
+{
+  value* closure = caml_named_value(name);
+  if ( NULL == closure ) {
+    caml_failwith("u3a_ocaml: missing callback");
+  }
+  return closure;
+}
+
+void
+u3a_ocaml_runtime_register(void)
+{
+  CAMLparam0();
+  static int registered = 0;
+  if ( !registered ) {
+    value* fn = named_function("u3a_ocaml_register_callbacks");
+    caml_callback(*fn, Val_unit);
+    registered = 1;
+  }
+  CAMLreturn0;
+}
+
+void
+u3a_ocaml_init_once(void)
+{
+  CAMLparam0();
+  value* fn = named_function("u3a_ocaml_init_once");
+  caml_callback(*fn, Val_unit);
+  CAMLreturn0;
+}
+
+void
+u3a_ocaml_init_heap(c3_w words)
+{
+  CAMLparam0();
+  value* fn = named_function("u3a_ocaml_init_heap");
+  caml_callback(*fn, Val_long(words));
+  CAMLreturn0;
+}
+
+void
+u3a_ocaml_drop_heap(c3_w cap, c3_w ear)
+{
+  CAMLparam0();
+  value* fn = named_function("u3a_ocaml_drop_heap");
+  caml_callback2(*fn, Val_long(cap), Val_long(ear));
+  CAMLreturn0;
+}
+
+void
+u3a_ocaml_mark_init(void)
+{
+  CAMLparam0();
+  value* fn = named_function("u3a_ocaml_mark_init");
+  caml_callback(*fn, Val_unit);
+  CAMLreturn0;
+}
+
+void
+u3a_ocaml_mark_done(void)
+{
+  CAMLparam0();
+  value* fn = named_function("u3a_ocaml_mark_done");
+  caml_callback(*fn, Val_unit);
+  CAMLreturn0;
+}
+
+static void*
+alloc_bigarray_block(const char* name, c3_w len)
+{
+  CAMLparam0();
+  CAMLlocal1(res);
+  value* fn = named_function(name);
+  res = caml_callback(*fn, Val_long(len));
+  void* data = Caml_ba_data_val(res);
+  mlsize_t words = Caml_ba_array_val(res)->dim[0];
+  register_block(data, res, words);
+  CAMLreturnT(void*, data);
+}
+
+void*
+u3a_ocaml_mark_alloc(c3_w len)
+{
+  return alloc_bigarray_block("u3a_ocaml_mark_alloc", len);
+}
+
+void
+u3a_ocaml_pack_init(void)
+{
+  CAMLparam0();
+  value* fn = named_function("u3a_ocaml_pack_init");
+  caml_callback(*fn, Val_unit);
+  CAMLreturn0;
+}
+
+void
+u3a_ocaml_pack_done(void)
+{
+  CAMLparam0();
+  value* fn = named_function("u3a_ocaml_pack_done");
+  caml_callback(*fn, Val_unit);
+  CAMLreturn0;
+}
+
+void*
+u3a_ocaml_pack_alloc(c3_w len)
+{
+  return alloc_bigarray_block("u3a_ocaml_pack_alloc", len);
+}
+
+void*
+u3a_ocaml_walloc(c3_w len)
+{
+  return alloc_bigarray_block("u3a_ocaml_walloc", len);
+}
+
+void*
+u3a_ocaml_wealloc(void* old_ptr, c3_w len)
+{
+  CAMLparam0();
+  CAMLlocal1(res);
+  block_entry* entry = find_block(old_ptr);
+  if ( NULL == entry ) {
+    caml_failwith("u3a_ocaml_wealloc: unknown block");
+  }
+  value* fn = named_function("u3a_ocaml_wealloc");
+  res = caml_callback2(*fn, entry->bigarray, Val_long(len));
+  void* data = Caml_ba_data_val(res);
+  mlsize_t words = Caml_ba_array_val(res)->dim[0];
+  remove_block(old_ptr);
+  register_block(data, res, words);
+  CAMLreturnT(void*, data);
+}
+
+void
+u3a_ocaml_wfree(void* ptr)
+{
+  CAMLparam0();
+  block_entry* entry = find_block(ptr);
+  if ( NULL == entry ) {
+    CAMLreturn0;
+  }
+  value* fn = named_function("u3a_ocaml_wfree");
+  caml_callback(*fn, entry->bigarray);
+  remove_block(ptr);
+  CAMLreturn0;
+}
+
+void
+u3a_ocaml_wtrim(void* ptr, c3_w old_len, c3_w new_len)
+{
+  CAMLparam0();
+  block_entry* entry = find_block(ptr);
+  if ( NULL == entry ) {
+    CAMLreturn0;
+  }
+  value* fn = named_function("u3a_ocaml_wtrim");
+  caml_callback3(*fn, entry->bigarray, Val_long(old_len), Val_long(new_len));
+  entry->length = new_len;
+  CAMLreturn0;
+}
+
+void*
+u3a_ocaml_calloc(c3_w num, c3_w len)
+{
+  CAMLparam0();
+  CAMLlocal1(res);
+  value* fn = named_function("u3a_ocaml_calloc");
+  res = caml_callback2(*fn, Val_long(num), Val_long(len));
+  void* data = Caml_ba_data_val(res);
+  mlsize_t words = Caml_ba_array_val(res)->dim[0];
+  register_block(data, res, words);
+  CAMLreturnT(void*, data);
+}
+
+void*
+u3a_ocaml_malloc(c3_w bytes)
+{
+  return alloc_bigarray_block("u3a_ocaml_malloc", bytes);
+}
+
+void*
+u3a_ocaml_celloc(void)
+{
+  CAMLparam0();
+  CAMLlocal1(res);
+  value* fn = named_function("u3a_ocaml_celloc");
+  res = caml_callback(*fn, Val_unit);
+  void* data = Caml_ba_data_val(res);
+  mlsize_t words = Caml_ba_array_val(res)->dim[0];
+  register_block(data, res, words);
+  CAMLreturnT(void*, data);
+}
+
+void
+u3a_ocaml_cfree(void* ptr)
+{
+  u3a_ocaml_wfree(ptr);
+}
+
+void*
+u3a_ocaml_realloc(void* ptr, c3_w bytes)
+{
+  if ( NULL == ptr ) {
+    return u3a_ocaml_malloc(bytes);
+  }
+  CAMLparam0();
+  CAMLlocal1(res);
+  block_entry* entry = find_block(ptr);
+  if ( NULL == entry ) {
+    caml_failwith("u3a_ocaml_realloc: unknown block");
+  }
+  value* fn = named_function("u3a_ocaml_realloc");
+  res = caml_callback2(*fn, entry->bigarray, Val_long(bytes));
+  void* data = Caml_ba_data_val(res);
+  mlsize_t words = Caml_ba_array_val(res)->dim[0];
+  remove_block(ptr);
+  register_block(data, res, words);
+  CAMLreturnT(void*, data);
+}
+
+void
+u3a_ocaml_free(void* ptr)
+{
+  if ( NULL == ptr ) {
+    return;
+  }
+  u3a_ocaml_wfree(ptr);
+}

--- a/ocaml/runtime/dune
+++ b/ocaml/runtime/dune
@@ -1,0 +1,4 @@
+(library
+ (name vere_runtime)
+ (modules noun allocate)
+ (libraries bigarray))

--- a/ocaml/runtime/noun.ml
+++ b/ocaml/runtime/noun.ml
@@ -1,0 +1,98 @@
+open Bigarray
+
+(** Runtime representation of urbit nouns in OCaml. Mirrors the 31-bit
+    immediate atom ("cat") and indirect pug/pom encodings used by the C
+    runtime. *)
+
+type tag =
+  | Cat  (** Immediate 31-bit atom. *)
+  | Pug  (** Indirect atom stored off-heap. *)
+  | Pom  (** Indirect cell stored off-heap. *)
+
+(** A pointer offset encoded in the low 30 bits of a noun word. *)
+type offset = int
+
+(** Indirect atom metadata. *)
+type pug = {
+  offset : offset;  (** Loom-style offset encoded in the noun tag. *)
+  length : int option;  (** Optional length in 32-bit words. *)
+  payload : (int32, int32_elt, c_layout) Array1.t option;
+      (** Optional backing store for OCaml-managed atoms. *)
+}
+
+(** Indirect cell metadata. *)
+type pom = {
+  offset : offset;  (** Loom-style offset encoded in the noun tag. *)
+  head : t option;  (** Optional OCaml shadow of the head noun. *)
+  tail : t option;  (** Optional OCaml shadow of the tail noun. *)
+}
+
+and t =
+  | Immediate of int32
+  | IndirectAtom of pug
+  | IndirectCell of pom
+
+let tag_mask = Int32.of_int 0xC0000000
+let cat_mask = Int32.of_int 0x80000000
+let pom_mask = Int32.of_int 0xC0000000
+let offset_mask = Int32.of_int 0x3FFFFFFF
+let cat_payload_mask = Int32.of_int 0x7FFFFFFF
+
+let low30 word = Int32.(to_int (logand word offset_mask))
+
+let sanitize_offset offset = Int32.logand offset offset_mask
+
+let tag_of_word word =
+  match Int32.logand word tag_mask with
+  | x when Int32.equal x Int32.zero -> Cat
+  | x when Int32.equal x cat_mask -> Pug
+  | x when Int32.equal x pom_mask -> Pom
+  | _ -> Pom (* should be unreachable, but treat as cell *)
+
+let offset_of_word word = low30 word
+
+let word_of_tag tag ~offset =
+  let off = sanitize_offset offset in
+  match tag with
+  | Cat -> Int32.logand off cat_payload_mask
+  | Pug -> Int32.logor cat_mask off
+  | Pom -> Int32.logor pom_mask off
+
+let is_cat word =
+  Int32.equal (Int32.logand word cat_mask) Int32.zero
+
+let is_pug word =
+  Int32.equal (Int32.logand word tag_mask) cat_mask
+
+let is_pom word =
+  Int32.equal (Int32.logand word tag_mask) pom_mask
+
+let to_word = function
+  | Immediate value ->
+      let payload = Int32.logand value cat_payload_mask in
+      word_of_tag Cat ~offset:payload
+  | IndirectAtom { offset; _ } -> word_of_tag Pug ~offset:(Int32.of_int offset)
+  | IndirectCell { offset; _ } -> word_of_tag Pom ~offset:(Int32.of_int offset)
+
+let of_word word =
+  match tag_of_word word with
+  | Cat -> Immediate (Int32.logand word cat_payload_mask)
+  | Pug ->
+      IndirectAtom
+        { offset = offset_of_word word; length = None; payload = None }
+  | Pom ->
+      IndirectCell { offset = offset_of_word word; head = None; tail = None }
+
+let immediate_value = function
+  | Immediate value -> Some value
+  | IndirectAtom _ | IndirectCell _ -> None
+
+let with_head_tail noun ~head ~tail =
+  match noun with
+  | IndirectCell cell -> IndirectCell { cell with head; tail }
+  | _ -> noun
+
+let with_payload noun ~payload =
+  match noun with
+  | IndirectAtom atom -> IndirectAtom { atom with payload }
+  | _ -> noun

--- a/ocaml/runtime/noun.mli
+++ b/ocaml/runtime/noun.mli
@@ -1,0 +1,65 @@
+(** Runtime representation of urbit nouns in OCaml. *)
+
+open Bigarray
+
+(** Bit-level tags that discriminate noun storage variants. *)
+type tag =
+  | Cat  (** Immediate 31-bit atom. *)
+  | Pug  (** Indirect atom stored off-heap. *)
+  | Pom  (** Indirect cell stored off-heap. *)
+
+(** A pointer offset encoded in the low 30 bits of a noun word. *)
+type offset = int
+
+(** Indirect atom metadata. *)
+type pug = {
+  offset : offset;  (** Loom-style offset encoded in the noun tag. *)
+  length : int option;  (** Optional length in 32-bit words. *)
+  payload : (int32, int32_elt, c_layout) Array1.t option;
+      (** Optional backing store for OCaml-managed atoms. *)
+}
+
+(** Indirect cell metadata. *)
+type pom = {
+  offset : offset;  (** Loom-style offset encoded in the noun tag. *)
+  head : t option;  (** Optional OCaml shadow of the head noun. *)
+  tail : t option;  (** Optional OCaml shadow of the tail noun. *)
+}
+
+and t =
+  | Immediate of int32
+  | IndirectAtom of pug
+  | IndirectCell of pom
+
+val tag_of_word : int32 -> tag
+(** [tag_of_word word] inspects the two high bits of [word] to recover the
+    noun tag. *)
+
+val offset_of_word : int32 -> offset
+(** Extract the 30-bit offset component of a noun word. *)
+
+val word_of_tag : tag -> offset:int32 -> int32
+(** [word_of_tag tag ~offset] constructs a noun word with the given tag and
+    offset payload. The [offset] argument is masked down to 30 bits. *)
+
+val is_cat : int32 -> bool
+val is_pug : int32 -> bool
+val is_pom : int32 -> bool
+
+val to_word : t -> int32
+(** Convert an OCaml noun descriptor back into a tagged noun word. *)
+
+val of_word : int32 -> t
+(** [of_word word] creates an OCaml noun descriptor that mirrors the tag and
+    offset encoded in [word]. Indirect payloads are initially opaque; callers
+    can attach OCaml-managed content by updating the returned record. *)
+
+val immediate_value : t -> int32 option
+(** Attempt to recover the immediate atomic value represented by a noun. *)
+
+val with_head_tail : t -> head:t option -> tail:t option -> t
+(** [with_head_tail noun ~head ~tail] enriches an indirect cell with OCaml
+    managed head and tail values. For non-cell nouns this is a no-op. *)
+
+val with_payload : t -> payload:(int32, int32_elt, c_layout) Array1.t option -> t
+(** Attach OCaml-managed storage to an indirect atom. *)

--- a/ocaml/runtime/tests/dune
+++ b/ocaml/runtime/tests/dune
@@ -1,0 +1,4 @@
+(test
+ (name runtime_tests)
+ (modules runtime_tests)
+ (libraries bigarray vere_runtime))

--- a/ocaml/runtime/tests/runtime_tests.ml
+++ b/ocaml/runtime/tests/runtime_tests.ml
@@ -1,0 +1,122 @@
+open Bigarray
+
+module N = Vere_runtime.Noun
+module A = Vere_runtime.Allocate
+
+let assert_bool msg cond =
+  if not cond then failwith msg
+
+let assert_int msg expected actual =
+  if expected <> actual then
+    failwith (Printf.sprintf "%s: expected %d, got %d" msg expected actual)
+
+let assert_int32 msg expected actual =
+  if not (Int32.equal expected actual) then
+    failwith
+      (Printf.sprintf "%s: expected %ld, got %ld" msg expected actual)
+
+let assert_all_zero msg arr =
+  let len = Array1.dim arr in
+  let rec loop idx =
+    if idx = len then ()
+    else begin
+      if not (Int32.equal Int32.zero (Array1.get arr idx)) then
+        failwith (Printf.sprintf "%s: index %d was non-zero" msg idx);
+      loop (idx + 1)
+    end
+  in
+  loop 0
+
+let noun_tests () =
+  let cat_value = Int32.of_int 42 in
+  let cat = N.Immediate cat_value in
+  let cat_word = N.to_word cat in
+  assert_bool "cat tag" (N.is_cat cat_word);
+  (match N.of_word cat_word with
+  | N.Immediate value -> assert_int32 "cat roundtrip" cat_value value
+  | _ -> failwith "cat lost immediacy");
+  let pug_word = N.word_of_tag N.Pug ~offset:(Int32.of_int 0x12345) in
+  assert_bool "pug tag" (N.is_pug pug_word);
+  assert_int "pug offset" 0x12345 (N.offset_of_word pug_word);
+  (match N.of_word pug_word with
+  | N.IndirectAtom { N.offset; _ } -> assert_int "pug record" 0x12345 offset
+  | _ -> failwith "pug decoding failed");
+  let pom_word = N.word_of_tag N.Pom ~offset:(Int32.of_int 0x222) in
+  assert_bool "pom tag" (N.is_pom pom_word);
+  (match N.of_word pom_word with
+  | N.IndirectCell { N.offset; _ } -> assert_int "pom offset" 0x222 offset
+  | _ -> failwith "pom decoding failed");
+  let rich_pom =
+    N.with_head_tail
+      (N.of_word pom_word)
+      ~head:(Some (N.Immediate (Int32.of_int 1)))
+      ~tail:(Some (N.Immediate (Int32.of_int 2)))
+  in
+  (match rich_pom with
+  | N.IndirectCell { N.head = Some head; tail = Some tail; _ } ->
+      assert_bool "head immediate" (Option.is_some (N.immediate_value head));
+      assert_bool "tail immediate" (Option.is_some (N.immediate_value tail))
+  | _ -> failwith "pom enrichment failed");
+  let rich_pug =
+    N.with_payload
+      (N.of_word pug_word)
+      ~payload:(Some (Array1.create Int32 C_layout 1))
+  in
+  match rich_pug with
+  | N.IndirectAtom { N.payload = Some payload; _ } ->
+      assert_int "payload length" 1 (Array1.dim payload)
+  | _ -> failwith "pug enrichment failed"
+
+let allocation_tests () =
+  A.init_once ();
+  A.init_heap ~words:128 ();
+  A.reset_profile ();
+  let allocations = ref 0 in
+  let frees = ref 0 in
+  let reallocations = ref 0 in
+  A.register_allocation_hook (fun words -> allocations := !allocations + words);
+  A.register_free_hook (fun words -> frees := !frees + words);
+  A.register_reallocation_hook
+    (fun old_words new_words -> reallocations := !reallocations + (new_words - old_words));
+  A.mark_init ();
+  let mark_buf = A.mark_alloc 8 in
+  assert_int "mark allocation length" 8 (Array1.dim mark_buf);
+  A.pack_init ();
+  let pack_buf = A.pack_alloc 4 in
+  assert_int "pack allocation length" 4 (Array1.dim pack_buf);
+  let block = A.waloc 16 in
+  assert_int "waloc length" 16 (Array1.dim block);
+  let block' = A.wealloc block 24 in
+  assert_int "wealloc length" 24 (Array1.dim block');
+  for i = 0 to Array1.dim block' - 1 do
+    Array1.set block' i (Int32.of_int i)
+  done;
+  let block'' = A.wealloc block' 12 in
+  assert_int "wealloc shrink" 12 (Array1.dim block'');
+  for i = 0 to Array1.dim block'' - 1 do
+    assert_int32 "wealloc copy" (Int32.of_int i) (Array1.get block'' i)
+  done;
+  let calloc_block = A.calloc 4 8 in
+  assert_int "calloc length" ((4 * 8 + 3) / 4) (Array1.dim calloc_block);
+  assert_all_zero "calloc zeroed" calloc_block;
+  let malloc_block = A.malloc 64 in
+  assert_int "malloc length" ((64 + 3) / 4) (Array1.dim malloc_block);
+  ignore (A.realloc None 32);
+  ignore (A.realloc (Some malloc_block) 32);
+  A.wfree block'';
+  A.free (Some calloc_block);
+  A.free None;
+  let snapshot = A.profile () in
+  assert_bool "allocations tracked" (snapshot.allocations >= 3);
+  assert_bool "frees tracked" (snapshot.frees >= 2);
+  assert_bool "realloc tracked" (snapshot.reallocations >= 2);
+  assert_bool "alloc hook" (!allocations > 0);
+  assert_bool "free hook" (!frees > 0);
+  assert_bool "realloc hook" (!reallocations <> 0);
+  A.pack_done ();
+  A.mark_done ();
+  A.drop_heap ~cap:0 ~ear:0
+
+let () =
+  noun_tests ();
+  allocation_tests ()

--- a/pkg/noun/allocate_ocaml.h
+++ b/pkg/noun/allocate_ocaml.h
@@ -1,0 +1,35 @@
+#ifndef U3_ALLOCATE_OCAML_H
+#define U3_ALLOCATE_OCAML_H
+
+#include "types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void u3a_ocaml_runtime_register(void);
+void u3a_ocaml_init_once(void);
+void u3a_ocaml_init_heap(c3_w words);
+void u3a_ocaml_drop_heap(c3_w cap, c3_w ear);
+void u3a_ocaml_mark_init(void);
+void u3a_ocaml_mark_done(void);
+void* u3a_ocaml_mark_alloc(c3_w len);
+void u3a_ocaml_pack_init(void);
+void u3a_ocaml_pack_done(void);
+void* u3a_ocaml_pack_alloc(c3_w len);
+void* u3a_ocaml_walloc(c3_w len);
+void* u3a_ocaml_wealloc(void* old_ptr, c3_w len);
+void u3a_ocaml_wfree(void* ptr);
+void u3a_ocaml_wtrim(void* ptr, c3_w old_len, c3_w new_len);
+void* u3a_ocaml_calloc(c3_w num, c3_w len);
+void* u3a_ocaml_malloc(c3_w bytes);
+void* u3a_ocaml_celloc(void);
+void u3a_ocaml_cfree(void* ptr);
+void* u3a_ocaml_realloc(void* ptr, c3_w bytes);
+void u3a_ocaml_free(void* ptr);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* U3_ALLOCATE_OCAML_H */


### PR DESCRIPTION
## Summary
- restructure the OCaml noun module so tag constructors are defined before use and keep masking consistent with the C layout
- fix allocator bookkeeping by distinguishing mark and pack buffers, zeroing bitsets, and making the callback registrar recursive
- add a dune workspace plus runtime tests that exercise noun conversions and allocator hooks

## Testing
- dune runtest

------
https://chatgpt.com/codex/tasks/task_e_68e1fe36e45c832cbd285f4dd9b9afa6